### PR TITLE
Allow decode to be a generic

### DIFF
--- a/qss.d.ts
+++ b/qss.d.ts
@@ -1,3 +1,3 @@
 export const encode: (obj: object, prefix?: string) => string
 
-export const decode: (str: string) => object
+export const decode: <MaybeObject extends object = {}>(str: string) => Partial<MaybeObject>


### PR DESCRIPTION
This allows the developers to type the output, maybe?

```ts
interface IQueryString {
    something: string;
}

const myObject = decode<IQueryString>(location.search.substring(1));

const something: string = myObject.something!; // notice the !
const something2: string = myObject.something2; // TypeError 🎉 
```

please give me feedback on the partial. Should we say that the interface passed in, is what _will_ come out, or follow the impl in that, _who knows whats going to come out_. but if we partially type, then we can say, it'll be defined, or not, and not allow them to pick anything else from the qs.