### PR TITLE
Add typecasting toggles

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -57,17 +57,27 @@ An optional prefix. The stringified `params` will be appended to this value, so 
 
 > **Important:** No checks or validations will run on your `prefix`. Similarly, no character is used to "glue" the query string to your `prefix` string.
 
-### qss.decode(query)
+### qss.decode(query, typecastBooleans, typecastNumbers)
 Returns: `Object`
 
-Returns an Object with decoded keys and values.
-
-Repetitive keys will form an Array of its values. Also, `qss` will attempt to typecast `Boolean` and `Number` values.
+Returns an Object with decoded keys and values. Repetitive keys will form an Array of its values.
 
 #### query
 Type: `String`
 
 The query string, without its leading `?` character.
+
+#### typecastBooleans
+Type: `Boolean`
+Default: `true`
+
+An optional Boolean typecast override. `qss` will attempt to typecast `Boolean` values by default.
+
+#### typecastNumbers
+Type: `Boolean`
+Default: `true`
+
+An optional Numbers typecast override. `qss` will attempt to typecast `Number` values by default.
 
 ```js
 qss.decode(

--- a/src/index.js
+++ b/src/index.js
@@ -18,24 +18,26 @@ export function encode(obj, pfx) {
 	return (pfx || '') + str;
 }
 
-function toValue(mix) {
+function toValue(mix,tcBools,tcNumbers) {
 	if (!mix) return '';
 	var str = decodeURIComponent(mix);
-	if (str === 'false') return false;
-	if (str === 'true') return true;
-	return (+str * 0 === 0) ? (+str) : str;
+	if (tcBools && str === 'false') return false;
+	if (tcBools && str === 'true') return true;
+	return (tcNumbers && +str * 0 === 0) ? (+str) : str;
 }
 
-export function decode(str) {
+export function decode(str,tcBools,tcNumbers) {
 	var tmp, k, out={}, arr=str.split('&');
+	tcBools = typeof tcBools !== 'undefined' ? tcBools : true;
+	tcNumbers = typeof tcNumbers !== 'undefined' ? tcNumbers : true;
 
 	while (tmp = arr.shift()) {
 		tmp = tmp.split('=');
 		k = tmp.shift();
 		if (out[k] !== void 0) {
-			out[k] = [].concat(out[k], toValue(tmp.shift()));
+			out[k] = [].concat(out[k], toValue(tmp.shift(),tcBools,tcNumbers));
 		} else {
-			out[k] = toValue(tmp.shift());
+			out[k] = toValue(tmp.shift(),tcBools,tcNumbers);
 		}
 	}
 

--- a/test/index.js
+++ b/test/index.js
@@ -82,7 +82,7 @@ test('(decode) simple', t => {
 	t.end();
 });
 
-test('(decode) numbers', t => {
+test('(decode) numbers with typecasting', t => {
 	let str = 'foo=1&bar=1&bar=2&baz=0';
 	let out = decode(str);
 	let val = parse(str);
@@ -93,7 +93,15 @@ test('(decode) numbers', t => {
 	t.end();
 });
 
-test('(decode) floats', t => {
+test('(decode) numbers without typecasting', t => {
+	let str = 'foo=1&bar=1&bar=2&baz=0';
+	let out = decode(str, true, false);
+	t.is(typeof out, 'object', 'returns an object');
+	t.same(out, { foo:'1', bar:['1', '2'], baz:'0' }, '~> is expected value');
+	t.end();
+});
+
+test('(decode) floats with typecasting', t => {
 	let str = 'foo=1&bar=1.3&bar=2.01&bar=2.0&baz=19.111';
 	let out = decode(str);
 	let val = parse(str);
@@ -104,7 +112,15 @@ test('(decode) floats', t => {
 	t.end();
 });
 
-test('(decode) booleans', t => {
+test('(decode) floats without typecasting', t => {
+	let str = 'foo=1&bar=1.3&bar=2.01&bar=2.0&baz=19.111';
+	let out = decode(str, true, false);
+	t.is(typeof out, 'object', 'returns an object');
+	t.same(out, { foo:'1', bar:['1.3', '2.01', '2.0'], baz: '19.111' }, '~> is expected value');
+	t.end();
+});
+
+test('(decode) booleans with typecasting', t => {
 	let str = 'foo=true&bar=false&bar=true';
 	let out = decode(str);
 	let val = parse(str);
@@ -112,6 +128,14 @@ test('(decode) booleans', t => {
 	t.same(out, { foo:true, bar:[false, true] }, '~> is expected value');
 	t.same(val, { foo:'true', bar:['false', 'true'] }, '>> assert native value, for reference');
 	t.not(out, val, 'does NOT match native value');
+	t.end();
+});
+
+test('(decode) booleans without typecasting', t => {
+	let str = 'foo=true&bar=false&bar=true';
+	let out = decode(str, false);
+	t.is(typeof out, 'object', 'returns an object');
+	t.same(out, { foo:'true', bar:['false', 'true'] }, '~> is expected value');
 	t.end();
 });
 


### PR DESCRIPTION
Fixes #7.

This PR adds the ability to toggle Boolean and Number typecasting by extending `decode`'s parameter signature from:
```js
qss.decode(query)
``` 
into:
```js
qss.decode(query, typecastBooleans, typecastNumbers)
```

I went ahead and updated the documentation and added corresponding tests. Please let me know what else I can do to facilitate this PR.