### PR TITLE
Improve performance by using URLSearchParams

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,10 @@
   "devDependencies": {
     "bundt": "^0.1.1",
     "tap-spec": "^5.0.0",
-    "tape": "^4.9.1"
+    "tape": "^4.9.1",
+    "benchmark": "^2.1.4",
+    "qs": "^6.9.6",
+    "query-string": "^6.13.8",
+    "querystringify": "^2.2.0"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -67,7 +67,7 @@ Repetitive keys will form an Array of its values. Also, `qss` will attempt to ty
 #### query
 Type: `String`
 
-The query string, without its leading `?` character.
+The query string, with or without its leading `?` character.
 
 ```js
 qss.decode(
@@ -78,26 +78,26 @@ qss.decode(
 
 ## Benchmarks
 
-> Running Node v10.13.0
+> Running Node v14.5.0
 
 ***Encode***
 
 ```
-qss             x 1,112,341 ops/sec ±0.24% (96 runs sampled)
-native          x 5,303,246 ops/sec ±0.76% (95 runs sampled)
-querystringify  x   950,501 ops/sec ±0.76% (96 runs sampled)
-query-string    x   347,603 ops/sec ±1.05% (92 runs sampled)
-qs              x   733,449 ops/sec ±0.62% (97 runs sampled)
+qss             x 1,151,789 ops/sec ±0.66% (89 runs sampled)
+native          x 4,432,282 ops/sec ±1.47% (90 runs sampled)
+querystringify  x   644,980 ops/sec ±0.70% (93 runs sampled)
+query-string    x   209,326 ops/sec ±0.63% (94 runs sampled)
+qs              x   514,285 ops/sec ±0.68% (89 runs sampled)
 ```
 
 ***Decode***
 
 ```
-qss             x   443,667 ops/sec ±0.17% (95 runs sampled)
-native          x   189,194 ops/sec ±0.44% (94 runs sampled)
-querystringify  x   282,169 ops/sec ±0.26% (96 runs sampled)
-query-string    x   191,334 ops/sec ±0.71% (95 runs sampled)
-qs              x   168,165 ops/sec ±0.41% (93 runs sampled)
+qss             x   504,873 ops/sec ±3.95% (87 runs sampled)
+native          x 1,148,267 ops/sec ±0.68% (94 runs sampled)
+querystringify  x   193,010 ops/sec ±0.94% (91 runs sampled)
+query-string    x   138,808 ops/sec ±1.15% (90 runs sampled)
+qs              x   137,275 ops/sec ±0.77% (94 runs sampled)
 ```
 
 ## License

--- a/src/index.js
+++ b/src/index.js
@@ -1,43 +1,36 @@
 export function encode(obj, pfx) {
-	var k, i, tmp, str='';
+	let params = new URLSearchParams();
 
-	for (k in obj) {
-		if ((tmp = obj[k]) !== void 0) {
-			if (Array.isArray(tmp)) {
-				for (i=0; i < tmp.length; i++) {
-					str && (str += '&');
-					str += encodeURIComponent(k) + '=' + encodeURIComponent(tmp[i]);
-				}
-			} else {
-				str && (str += '&');
-				str += encodeURIComponent(k) + '=' + encodeURIComponent(tmp);
+	Object.entries(obj).forEach(([k, v]) => {
+		if (Array.isArray(v)) {
+			for (let i = 0; i < v.length; i++) {
+				params.append(k, v[i]);
 			}
+		} else {
+			params.append(k, v);
 		}
-	}
+	});
 
-	return (pfx || '') + str;
+	return `${(pfx || '')}${params}`;
 }
 
-function toValue(mix) {
-	if (!mix) return '';
-	var str = decodeURIComponent(mix);
+function toValue(str) {
+	if (!str) return '';
 	if (str === 'false') return false;
 	if (str === 'true') return true;
 	return (+str * 0 === 0) ? (+str) : str;
 }
 
 export function decode(str) {
-	var tmp, k, out={}, arr=str.split('&');
+	let out = {};
 
-	while (tmp = arr.shift()) {
-		tmp = tmp.split('=');
-		k = tmp.shift();
-		if (out[k] !== void 0) {
-			out[k] = [].concat(out[k], toValue(tmp.shift()));
+	(new URLSearchParams(str)).forEach((v, k) => {
+		if (out[k] !== undefined) {
+			out[k] = [].concat(out[k], toValue(v));
 		} else {
-			out[k] = toValue(tmp.shift());
+			out[k] = toValue(v);
 		}
-	}
+	});
 
 	return out;
 }


### PR DESCRIPTION
Hey 👋 

I've been wondering if performance could be improved by using the natively available URLSearchParams object to parse and encode query parameters.

This PR is the result of that experiment.

Before the benchmark looked like this on my machine:
<img width="424" alt="Screenshot 2021-01-19 at 11 07 07" src="https://user-images.githubusercontent.com/5417642/105021043-5e3af780-5a48-11eb-92bc-9053b6af97e9.png">

After it looks like this:
<img width="426" alt="Screenshot 2021-01-19 at 11 09 57" src="https://user-images.githubusercontent.com/5417642/105021059-66933280-5a48-11eb-9f66-1f5ac2a7ff45.png">

It seems to me that size is reduced and speed is increased at the same time.

It also seemed to make sense to me to update the benchmarks in the readme along with it and to add the required benchmark dependencies to the `devDependencies`.

I also noted that `*.lock` is in the `.gitignore` and that no lockfile is checked in. I assume this is intended?

Anyway - I'm interested in your thoughts on this :)