### PR TITLE
Support import.meta.resolve

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,17 @@
   "main": "dist/qss.js",
   "types": "qss.d.ts",
   "exports": {
-    "import": "./dist/qss.mjs"
+    ".": {
+      "import": "./dist/qss.m.js",
+      "require": "./dist/qss.js",
+      "default": "./dist/qss.js"
+    },
+    "./dist/qss.mjs": "./dist/qss.mjs",
+    "./dist/qss.js": "./dist/qss.js",
+    "./dist/qss.min.js": "./dist/qss.min.js",
+    "./dist/qss.m.js": "./dist/qss.m.js",
+    "./qss.d.ts": "./qss.d.ts",
+    "./package.json": "./package.json"
   },
   "license": "MIT",
   "files": [

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "param"
   ],
   "devDependencies": {
-    "bundt": "^0.1.1",
+    "bundt": "0.2.1",
     "tap-spec": "^5.0.0",
     "tape": "^4.9.1"
   }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
   "module": "dist/qss.mjs",
   "main": "dist/qss.js",
   "types": "qss.d.ts",
-  "type": "module",
   "exports": {
     ".": {
       "import": "./dist/qss.mjs",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
   "module": "dist/qss.m.js",
   "main": "dist/qss.js",
   "types": "qss.d.ts",
+  "exports": {
+    "import": "./dist/qss.mjs"
+  },
   "license": "MIT",
   "files": [
     "*.d.ts",

--- a/package.json
+++ b/package.json
@@ -4,20 +4,20 @@
   "repository": "lukeed/qss",
   "description": "A tiny (305B) browser utility for stringifying a query Object.",
   "unpkg": "dist/qss.min.js",
-  "module": "dist/qss.m.js",
+  "module": "dist/qss.mjs",
   "main": "dist/qss.js",
   "types": "qss.d.ts",
   "type": "module",
   "exports": {
     ".": {
-      "import": "./dist/qss.m.js",
-      "require": "./dist/qss.js",
+      "import": "./dist/qss.mjs",
+      "require": "./dist/qss.cjs",
       "default": "./dist/qss.js"
     },
     "./dist/qss.mjs": "./dist/qss.mjs",
+    "./dist/qss.cjs": "./dist/qss.cjs",
     "./dist/qss.js": "./dist/qss.js",
     "./dist/qss.min.js": "./dist/qss.min.js",
-    "./dist/qss.m.js": "./dist/qss.m.js",
     "./qss.d.ts": "./qss.d.ts",
     "./package.json": "./package.json"
   },
@@ -35,7 +35,7 @@
     "node": ">=4"
   },
   "scripts": {
-    "build": "bundt",
+    "build": "bundt && cp dist/qss.js dist/qss.cjs",
     "bench": "node bench",
     "pretest": "npm run build",
     "prebench": "npm run build",

--- a/package.json
+++ b/package.json
@@ -7,20 +7,15 @@
   "module": "dist/qss.mjs",
   "main": "dist/qss.js",
   "types": "qss.d.ts",
+  "license": "MIT",
   "exports": {
     ".": {
+      "types": "./qss.d.ts",
       "import": "./dist/qss.mjs",
-      "require": "./dist/qss.cjs",
-      "default": "./dist/qss.js"
+      "require": "./dist/qss.js"
     },
-    "./dist/qss.mjs": "./dist/qss.mjs",
-    "./dist/qss.cjs": "./dist/qss.cjs",
-    "./dist/qss.js": "./dist/qss.js",
-    "./dist/qss.min.js": "./dist/qss.min.js",
-    "./qss.d.ts": "./qss.d.ts",
     "./package.json": "./package.json"
   },
-  "license": "MIT",
   "files": [
     "*.d.ts",
     "dist"
@@ -34,10 +29,7 @@
     "node": ">=4"
   },
   "scripts": {
-    "build": "bundt && cp dist/qss.js dist/qss.cjs",
-    "bench": "node bench",
-    "pretest": "npm run build",
-    "prebench": "npm run build",
+    "build": "bundt",
     "test": "tape test/*.js | tap-spec"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "module": "dist/qss.m.js",
   "main": "dist/qss.js",
   "types": "qss.d.ts",
+  "type": "module",
   "exports": {
     ".": {
       "import": "./dist/qss.m.js",


### PR DESCRIPTION
This exports field is needed for import.meta.resolve to find the file location of a node_modules import.

exports: https://nodejs.org/api/packages.html#exports
import.meta.resolve: https://www.npmjs.com/package/import-meta-resolve

I need this in order to get my package [`web-imports`](https://www.npmjs.com/package/web-imports) to bundle my other package [`grainbox`](https://www.npmjs.com/package/grainbox) properly for CDN usage.