### PR TITLE
handle number values precision

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,5 @@
+var isSafeInteger = Number.isSafeInteger;
+
 export function encode(obj, pfx) {
 	var k, i, tmp, str='';
 
@@ -23,7 +25,9 @@ function toValue(mix) {
 	var str = decodeURIComponent(mix);
 	if (str === 'false') return false;
 	if (str === 'true') return true;
-	return (+str * 0 === 0) ? (+str) : str;
+	
+	var num = +str;
+	return (num * 0 === 0 && isSafeInteger(num)) ? num : str;
 }
 
 export function decode(str) {


### PR DESCRIPTION
Due to the default number parsing used, when the number is large, the number precision may be lost,
such as:

```js
var str = '9012073974900851737';
+str; // 9012073974900852000
```

Therefore, the correction is only to automatically parse the numbers within the safety precision.